### PR TITLE
feat: env variable to set notification urgency

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -36,11 +37,22 @@ func notify(input string) {
 		"/org/freedesktop/Notifications",
 	)
 
+	// See https://bugzilla.suse.com/show_bug.cgi?id=1219525, some distros
+	// do not handle normal notifications in a way that the user can see them
+	// when not looked at fast enough.
+	//
+	// These systems can set TRANSACTIONAL_UPDATE_NOTIFY_URGENT=1 env variable
+	// to force the use of high priority urgent notifications that will stick.
+	urgency := byte(1)
+	if os.Getenv("TRANSACTIONAL_UPDATE_NOTIFY_URGENT") == "1" {
+		urgency = byte(2)
+	}
+
 	// Set hints of the notification, in this case we set it to
 	// an urgent notification, so we're sure that it will stick
 	// in the tray, and the user is notified.
 	hints := map[string]dbus.Variant{
-		"urgency":  dbus.MakeVariant(byte(1)),
+		"urgency":  dbus.MakeVariant(urgency),
 		"category": dbus.MakeVariant("device"),
 	}
 


### PR DESCRIPTION
This is a potential fix for https://bugzilla.suse.com/show_bug.cgi?id=1219525

Systems that need sticky/urgent notifications can set that env variable
`TRANSACTIONAL_UPDATE_NOTIFY_URGENT=1`

Else for systems like Aeon, no changes for the default behaviour.