### PR TITLE
set notification app name to 'System Updater'

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -59,7 +59,7 @@ func notify(input string) {
 	call := obj.Call(
 		"org.freedesktop.Notifications.Notify",
 		0,
-		"",
+		"System Updater",
 		uint32(0),
 		icon,
 		message,


### PR DESCRIPTION
it will show "System Updater" instead of "Unknown App" in the notification title.
This fixes a bug on Aeon Desktop: https://bugzilla.opensuse.org/show_bug.cgi?id=1229037.